### PR TITLE
Elitism by interval

### DIFF
--- a/OpenCLGA/ocl_ga.py
+++ b/OpenCLGA/ocl_ga.py
@@ -173,6 +173,8 @@ class OpenCLGA():
     # @var __elitism_top The number of elites to be picked in each generation.
     # @var __elitism_every The number of rounds for server to notify all clients
     #                      that newly sorted elites are coming
+    # @var __elitism_interval The interval to get current elites since last time.
+    # @var __elitism_last_retrieval The timestamp of last time when retrieving elites.
     # @var __elites_updated Indicating that newly sorted elites are received.
     #                       These elites are going to be updated into dev memory.
     # @var __best_fitnesses The list of top N best fitnesses
@@ -205,7 +207,7 @@ class OpenCLGA():
 
         # For elitism_mode
         elitism_info = options.get('elitism_mode', {})
-        self.__elitism_top = elitism_info.get('top', 0)
+        self.__elitism_top = elitism_info.get('top', 1)
         self.__elitism_every = elitism_info.get('every', 0)
         self.__is_elitism_mode = all([self.__elitism_top, self.__elitism_every])
         self.__elites_updated = False

--- a/OpenCLGA/ocl_ga_server.py
+++ b/OpenCLGA/ocl_ga_server.py
@@ -141,7 +141,7 @@ class OpenCLGAServer(Logger):
     ## To centralized the default value for local initialization and parameters
     #  from UI or example server.
     def __update_elitism_members(self, elitism_info):
-        self.elitism_top = elitism_info.get('top', 0)
+        self.elitism_top = elitism_info.get('top', 1)
         self.elitism_every = elitism_info.get('every', 0)
         self.is_elitism_mode = all([self.elitism_top, self.elitism_every])
         self.info('Elitism mode is {}, top({})/every({})'.format(self.is_elitism_mode,
@@ -292,6 +292,12 @@ class OpenCLGAServer(Logger):
 
     def __update_elite_list(self, best_result, worker_id):
         self.__restore_elite_list()
+
+        # Since client may not send elites back every generation.
+        # Return early if there's no elites.
+        if not all([k in best_result for k in ['elites', 'fitnesses', 'dna_size']]):
+            return
+
         elites = best_result['elites']
         elite_fitnesses = best_result['fitnesses']
         elite_size = best_result['dna_size']

--- a/examples/taiwan_travel/taiwan_travel_server.py
+++ b/examples/taiwan_travel/taiwan_travel_server.py
@@ -71,7 +71,7 @@ def get_taiwan_travel_info():
                   'extinction': { 'type': 'best_avg',
                                   'diff': 1,
                                   'ratio': 0.9 },
-                  'elitism_mode' : { 'top' : 3, 'every' : 10, 'interval' : 20 }}
+                  'elitism_mode' : { 'every' : 10, 'interval' : 20 }}
     return dict_info
 
 lines_input = ''

--- a/examples/taiwan_travel/taiwan_travel_server.py
+++ b/examples/taiwan_travel/taiwan_travel_server.py
@@ -71,7 +71,7 @@ def get_taiwan_travel_info():
                   'extinction': { 'type': 'best_avg',
                                   'diff': 1,
                                   'ratio': 0.9 },
-                  'elitism_mode' : { 'top' : 3, 'every' : 10 }}
+                  'elitism_mode' : { 'top' : 3, 'every' : 10, 'interval' : 20 }}
     return dict_info
 
 lines_input = ''


### PR DESCRIPTION
1) Set default elitism top to 1 to reduce the network loading and the possibility of local best solution.
2) Trigger an elitism exchange mechanism by a time interval to reduce the network loading.